### PR TITLE
Add required auth settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Discourse mojeID plugin
+
+Plugin to login to [Discourse forum](https://discourse.org/) via
+[mojeID](https://mojeid.cz/) identity provider.
+
+
+## Insatallation
+
+With [discourse_docker](https://github.com/discourse/discourse_docker)
+
+Add plugin URL among plugins in `containers/app.yml`:
+
+```yaml
+hooks:
+  after_code:
+    - exec:
+        cd: $home/plugins
+        cmd:
+          - git clone https://github.com/CZ-NIC/discourse-mojeid.git
+```

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,8 @@
+---
+# mojeID plugin translations
+
+en:
+  site_settings:
+    mojeid_enabled: "Enable mojeID plugin"
+
+...

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,9 @@
+---
+# MojeID plugin settngs
+
+plugins:
+  mojeid_enabled:
+    default: true
+    client: true
+
+...

--- a/plugin.rb
+++ b/plugin.rb
@@ -5,7 +5,7 @@
 # authors: Ondřej Surý
 
 auth_provider :title => 'with mojeID',
-              :authenticator => Auth::OpenIdAuthenticator.new('mojeid','https://mojeid.cz/endpoint/', trusted: true),
+              :authenticator => Auth::OpenIdAuthenticator.new('mojeid', 'https://mojeid.cz/endpoint/', 'mojeid_enabled', trusted: true),
               :message => 'Authenticating with mojeID (make sure pop up blockers are not enabled)',
               :frame_width => 530,   # the frame size used for the pop up window, overrides default
               :frame_height => 600

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 # name: discourse-mojeid
 # about: mojeID login support for Discourse
 # version: 0.0.1
-# authors: Ondřej Surý
+# authors: Ondřej Surý, Vojtěch Myslivec
 
 auth_provider :title => 'with mojeID',
               :authenticator => Auth::OpenIdAuthenticator.new('mojeid', 'https://mojeid.cz/endpoint/', 'mojeid_enabled', trusted: true),

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 # name: discourse-mojeid
 # about: mojeID login support for Discourse
-# version: 0.0.1
+# version: 0.0.2
 # authors: Ondřej Surý, Vojtěch Myslivec
 
 auth_provider :title => 'with mojeID',


### PR DESCRIPTION
Make plugin compatible with discourse 2.1.0

Fix #1 
